### PR TITLE
Update build-check.yaml

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Create GitHub Release
         id: create_release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       # Create a release on GitHub using GITHUB_TOKEN
       - name: Create GitHub Release


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to modify how the current date is stored. Specifically, the changes involve updating the method used to save the date to the environment.

Changes to GitHub Actions workflows:

* [`.github/workflows/build-check.yaml`](diffhunk://#diff-c72566b99b5b216221781432fb458a65bcddcd82ce9ae7ed492b05eab055a9afL45-R45): Changed the command to store the current date from `$GITHUB_OUTPUT` to `$GITHUB_ENV`.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L48-R48): Changed the command to store the current date from `$GITHUB_OUTPUT` to `$GITHUB_ENV`.