### PR TITLE
Voeg upload van ISO-artifact toe en verbeter datumvariabele in build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,15 @@ jobs:
         run: |
           docker cp arch-container:/workdir/out/Arch.iso ${{ github.workspace }}/ || echo 'Failed to copy ISO to host.'
 
+      - name: Upload ISO Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Arch.iso
+          path: ${{ github.workspace }}/Arch.iso
+
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       # Create a release on GitHub using GITHUB_TOKEN
       - name: Create GitHub Release
@@ -54,10 +60,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ github.run_id }}-release
+          tag_name: "v${{ github.run_id }}-release"
           release_name: "Arch Linux Release"
           body: |
-            This release contains the Arch Linux ISO built on ${{ steps.date.outputs.date }}.
+            This release contains the Arch Linux ISO built on ${{ env.DATE }}.
           draft: false
           prerelease: false
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for building and releasing an Arch Linux ISO. The changes primarily focus on artifact handling and environment variable usage.

Improvements to artifact handling:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R46-R54): Added a step to upload the generated Arch Linux ISO as an artifact using the `actions/upload-artifact@v3` action.

Enhancements to environment variable usage:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R46-R54): Modified the step to set the date environment variable to use uppercase `DATE` instead of lowercase `date`.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L57-R66): Updated the release creation step to use the `DATE` environment variable instead of the `date` output from the previous step.