### PR TITLE
Fix workspace variable usage in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ on:
 env:
   DOCKER_BUILDKIT: 1
   ISO_FILENAME: Arch.iso
+  WORKSPACE: ${{ github.workspace }}
 
 jobs:
   build:
@@ -36,7 +37,7 @@ jobs:
       - name: Set up Arch Linux Container
         run: |
           docker run --privileged --name arch-container -d \
-            -v ${{ env.WORKSPACE }}:/workdir \
+            -v ${WORKSPACE}:/workdir \
             -v /tmp/pacman-cache:/var/cache/pacman/pkg \
             archlinux:latest sleep infinity
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build.yaml` file to improve the workflow configuration. The most important changes include the addition of a new environment variable and the correction of a variable reference within a Docker command.

Workflow configuration improvements:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R18): Added the `WORKSPACE` environment variable to the workflow configuration.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L39-R40): Corrected the variable reference from `${{ env.WORKSPACE }}` to `${WORKSPACE}` in the Docker run command.