### PR TITLE
Remove QEMU bootability tests and cache pacman packages step

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Cache Pacman packages
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.PACMAN_CACHE }}
-          key: pacman-${{ runner.os }}-${{ github.sha }}
-          restore-keys: |
-            pacman-${{ runner.os }}-
-
       - name: Set up Arch Linux Container
         run: |
           mkdir -p ${{ env.PACMAN_CACHE }}
@@ -89,12 +81,6 @@ jobs:
             sha256sum \"\$iso_file\" > checksum.sha256
             sha256sum -c checksum.sha256 || {
               echo '::error::ISO checksum verification failed'
-              exit 1
-            }
-
-            # Verify ISO bootability
-            qemu-system-x86_64 -cdrom \"\$iso_file\" -boot d -m 512 -nographic -net none -no-reboot -serial mon:stdio -display none -kernel /boot/vmlinuz-linux -initrd /boot/initramfs-linux.img -append \"console=ttyS0\" || {
-              echo '::error::ISO bootability test failed'
               exit 1
             }
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,12 @@ The GitHub Actions workflow automatically builds and releases the ISO. Here’s 
 - **Steps**:
   1. **Checkout Repository**: Pulls the latest files from the repository.
   2. **Set up Environment Variables**: Initializes necessary environment variables.
-  3. **Cache Pacman Packages**: Caches packages to speed up the build process.
-  4. **Set up Arch Linux Container**: Initializes the build environment.
-  5. **Build ISO**: Builds the ISO using `mkarchiso`.
-  6. **Generate Checksums**: Creates SHA256 and SHA512 checksums for the ISO.
-  7. **Rename and Move ISO**: Renames the ISO file and moves it to the output directory.
-  8. **Generate Release Notes**: Creates release notes for the new ISO.
-  9. **Create Release**: Uploads the ISO and checksums as a new release on GitHub.
+  3. **Set up Arch Linux Container**: Initializes the build environment.
+  4. **Build ISO**: Builds the ISO using `mkarchiso`.
+  5. **Generate Checksums**: Creates SHA256 and SHA512 checksums for the ISO.
+  6. **Rename and Move ISO**: Renames the ISO file and moves it to the output directory.
+  7. **Generate Release Notes**: Creates release notes for the new ISO.
+  8. **Create Release**: Uploads the ISO and checksums as a new release on GitHub.
 
 #### Check Dockerfile
 


### PR DESCRIPTION
Fixes issue #65

Remove the QEMU bootability test and the "Cache Pacman packages" step from the build-check workflow.

* **README.md**
  - Update the documentation to reflect the removal of the QEMU bootability test.
  - Update the documentation to reflect the removal of the "Cache Pacman packages" step.

* **.github/workflows/build-check.yaml**
  - Remove the "Cache Pacman packages" step.
  - Remove the QEMU bootability test from the "Verify ISO" step.

