### PR TITLE
Fix Dockerfile to include mkarchiso execution

### DIFF
--- a/.github/workflows/dockerfile-check.yaml
+++ b/.github/workflows/dockerfile-check.yaml
@@ -20,4 +20,38 @@ jobs:
         run: |
           set -e  # Exit immediately if a command exits with a non-zero status
           docker build -t arch-iso-builder . || { echo "Docker build failed"; exit 1; }
-          docker run --rm --privileged -v "$(pwd)":/workdir arch-iso-builder bash -c "mkarchiso -v -w workdir/ -o out/ ." || { echo "ISO creation failed"; exit 1; }
+
+      - name: Verify ISO
+        run: |
+          set -e  # Exit immediately if a command exits with a non-zero status
+          cd out/
+          
+          # Check if ISO exists
+          iso_count=$(ls -1 *.iso 2>/dev/null | wc -l)
+          if [ $iso_count -eq 0 ]; then
+            echo '::error::No ISO file found'
+            exit 1
+          elif [ $iso_count -gt 1 ]; then
+            echo '::error::Multiple ISO files found'
+            exit 1
+          fi
+          
+          iso_file=$(ls *.iso)
+          
+          # Check ISO size (minimum 500MB)
+          size=$(stat -c%s "$iso_file")
+          if [ $size -lt 524288000 ]; then
+            echo "::error::ISO file too small: $((size / 1024 / 1024))MB"
+            exit 1
+          fi
+          
+          # Verify ISO checksum
+          sha256sum "$iso_file" > checksum.sha256
+          sha256sum -c checksum.sha256 || {
+            echo '::error::ISO checksum verification failed'
+            exit 1
+          }
+
+          # Generate additional checksums
+          md5sum "$iso_file" > checksum.md5
+          sha1sum "$iso_file" > checksum.sha1

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ To install Docker, follow the instructions for your operating system:
 
 3. **Build the ISO in the container**:
 
-   Build the ISO with this command:
+   The Dockerfile now includes the `mkarchiso` command to automate the ISO build process. Simply run the container to build the ISO:
 
    ```bash
-   docker run --rm --privileged -v $(pwd):/workdir arch-iso-builder bash -c "mkarchiso -v -w workdir/ -o out/ ."
+   docker run --rm --privileged -v $(pwd):/workdir arch-iso-builder
    ```
 
 4. **Retrieve the ISO**:

--- a/dockerfile
+++ b/dockerfile
@@ -10,6 +10,8 @@ WORKDIR /workdir
 # Copy files into the container
 COPY . .
 
-# Instead of running mkarchiso here, we leave it for later execution
+# Run mkarchiso to build the ISO
+RUN mkarchiso -v -w /workdir/workdir -o /workdir/out .
+
 # Create an entrypoint or leave it to manual execution
 CMD ["/bin/bash"]


### PR DESCRIPTION
Fixes #77

Update Dockerfile to include mkarchiso execution and enhance workflow checks.

* **Dockerfile**:
  - Add `RUN mkarchiso -v -w /workdir/workdir -o /workdir/out .` to execute `mkarchiso` command.
  - Add comments to explain the purpose of each command and section.

* **README.md**:
  - Update the "Build the ISO in the container" section to reflect the automated `mkarchiso` execution.

* **.github/workflows/dockerfile-check.yaml**:
  - Add a step to verify the ISO file's integrity and size after the build process.
  - Add comments to explain the purpose of each step in the workflow.

