### PR TITLE
Fix release tag workflow

### DIFF
--- a/.github/workflows/automated-tagging-versioning.yaml
+++ b/.github/workflows/automated-tagging-versioning.yaml
@@ -18,10 +18,19 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Install Semantic Release
         run: npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
+
+      - name: Unset Git Configurations
+        run: |
+          git config --global --unset-all user.name || true
+          git config --global --unset-all user.email || true
+
+      - name: Kill Orphan Processes
+        run: |
+          pkill -f node || true
 
       - name: Automated Tagging and Versioning
         env:


### PR DESCRIPTION
Fixes #80

Update the Node.js version and add cleanup steps in the Release tag workflow.

* **Update Node.js Version**
  - Change Node.js version from `14` to `18` in the `Set up Node.js` step.

* **Add Cleanup Steps**
  - Add a step to unset all Git configurations before the `Automated Tagging and Versioning` step.
  - Add a step to kill any orphan processes before the `Automated Tagging and Versioning` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Githubguy132010/Arch-Linux-without-the-beeps/pull/81?shareId=d12036dc-5b05-48b7-a2c7-c4155898dc07).