### PR TITLE
Fix GitHub plugin TypeError in fail step

### DIFF
--- a/.github/workflows/automated-tagging-versioning.yaml
+++ b/.github/workflows/automated-tagging-versioning.yaml
@@ -35,4 +35,13 @@ jobs:
       - name: Automated Tagging and Versioning
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release
+          FAIL_COMMENT_NAME: "Automated Tagging and Versioning"
+          FAIL_COMMENT_MESSAGE: "An error occurred during the automated tagging and versioning process."
+          FAIL_COMMENT_CONTEXT: "GitHub Actions Workflow"
+          FAIL_COMMENT_DETAILS: "Check the logs for more details."
+        run: |
+          export FAIL_COMMENT_NAME="Automated Tagging and Versioning"
+          export FAIL_COMMENT_MESSAGE="An error occurred during the automated tagging and versioning process."
+          export FAIL_COMMENT_CONTEXT="GitHub Actions Workflow"
+          export FAIL_COMMENT_DETAILS="Check the logs for more details."
+          semantic-release

--- a/.github/workflows/automated-tagging-versioning.yaml
+++ b/.github/workflows/automated-tagging-versioning.yaml
@@ -40,8 +40,4 @@ jobs:
           FAIL_COMMENT_CONTEXT: "GitHub Actions Workflow"
           FAIL_COMMENT_DETAILS: "Check the logs for more details."
         run: |
-          export FAIL_COMMENT_NAME="Automated Tagging and Versioning"
-          export FAIL_COMMENT_MESSAGE="An error occurred during the automated tagging and versioning process."
-          export FAIL_COMMENT_CONTEXT="GitHub Actions Workflow"
-          export FAIL_COMMENT_DETAILS="Check the logs for more details."
           semantic-release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -161,6 +161,11 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         if: github.ref == 'refs/heads/main'
+        env:
+          FAIL_COMMENT_NAME: "Create Release"
+          FAIL_COMMENT_MESSAGE: "An error occurred during the release creation process."
+          FAIL_COMMENT_CONTEXT: "GitHub Actions Workflow"
+          FAIL_COMMENT_DETAILS: "Check the logs for more details."
         with:
           tag_name: v${{ env.VERSION }}
           name: "Arch Linux No Beeps v${{ env.VERSION }}"

--- a/.github/workflows/generate-release-notes.yaml
+++ b/.github/workflows/generate-release-notes.yaml
@@ -15,6 +15,11 @@ jobs:
       - name: Generate Release Notes
         id: generate_release_notes
         uses: release-drafter/release-drafter@v5
+        env:
+          FAIL_COMMENT_NAME: "Generate Release Notes"
+          FAIL_COMMENT_MESSAGE: "An error occurred during the release notes generation process."
+          FAIL_COMMENT_CONTEXT: "GitHub Actions Workflow"
+          FAIL_COMMENT_DETAILS: "Check the logs for more details."
         with:
           config-name: release-drafter.yml
 


### PR DESCRIPTION
Related to #82

Add environment variables for fail comments in GitHub Actions workflows.

* **Automated Tagging and Versioning**: Add environment variables `FAIL_COMMENT_NAME`, `FAIL_COMMENT_MESSAGE`, `FAIL_COMMENT_CONTEXT`, and `FAIL_COMMENT_DETAILS` to the `Automated Tagging and Versioning` job in `.github/workflows/automated-tagging-versioning.yaml`. Ensure the `semantic-release` command uses these environment variables.
* **Generate Release Notes**: Add environment variables `FAIL_COMMENT_NAME`, `FAIL_COMMENT_MESSAGE`, `FAIL_COMMENT_CONTEXT`, and `FAIL_COMMENT_DETAILS` to the `Generate Release Notes` job in `.github/workflows/generate-release-notes.yaml`.
* **Create Release**: Add environment variables `FAIL_COMMENT_NAME`, `FAIL_COMMENT_MESSAGE`, `FAIL_COMMENT_CONTEXT`, and `FAIL_COMMENT_DETAILS` to the `Create Release` job in `.github/workflows/build.yaml`.

