### PR TITLE
Add workflow to delete old releases with configurable retention

### DIFF
--- a/.github/workflows/delete-old-releases.yaml
+++ b/.github/workflows/delete-old-releases.yaml
@@ -1,0 +1,25 @@
+name: Delete Old Releases
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      keep_latest:
+        description: 'Number of latest releases to keep'
+        required: true
+        default: '1'
+
+jobs:
+  delete-old-releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete old releases
+        uses: dev-drprasad/delete-older-releases@v0.3.2
+        with:
+          keep_latest: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_latest || '5' }}
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-old-releases.yaml
+++ b/.github/workflows/delete-old-releases.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Delete old releases
         uses: dev-drprasad/delete-older-releases@v0.3.2
         with:
-          keep_latest: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_latest || '5' }}
+          keep_latest: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.keep_latest || '1' }}
           delete_tags: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new workflow to automate the deletion of old releases. The workflow is triggered on release publication and can also be manually dispatched with a specific number of releases to keep.

New workflow addition:

* [`.github/workflows/delete-old-releases.yaml`](diffhunk://#diff-7ea4a7adbba5ec1b0b8400f8c0d41295307efefba5928aa74e8e23ca5d05a467R1-R25): Added a new workflow named "Delete Old Releases" to automatically delete old releases while keeping a specified number of the latest releases. The workflow uses the `dev-drprasad/delete-older-releases@v0.3.2` action and is configured to run on `ubuntu-latest`. It includes a `workflow_dispatch` input to specify the number of latest releases to keep, with a default value of 1.