### PR TITLE
Fix systemd service configuration overwriting comprehensive modprobe config

### DIFF
--- a/airootfs/etc/systemd/system/no-beep.service
+++ b/airootfs/etc/systemd/system/no-beep.service
@@ -9,8 +9,6 @@ After=local-fs.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/bash -c "rmmod pcspkr snd_pcsp 2>/dev/null || true"
-ExecStart=/bin/bash -c "echo 'blacklist pcspkr' > /etc/modprobe.d/nobeep.conf"
-ExecStart=/bin/bash -c "echo 'blacklist snd_pcsp' >> /etc/modprobe.d/nobeep.conf"
 ExecStart=/bin/bash -c "if [ -f /sys/module/i8042/parameters/nopnp ]; then echo 1 > /sys/module/i8042/parameters/nopnp; fi"
 
 [Install]


### PR DESCRIPTION
## Description
This pull request fixes issue #115 by removing the commands in `no-beep.service` that overwrite the comprehensive modprobe configuration file.

## Changes Made
- Removed the following lines from `no-beep.service`:
  ```
  ExecStart=/bin/bash -c "echo 'blacklist pcspkr' > /etc/modprobe.d/nobeep.conf"
  ExecStart=/bin/bash -c "echo 'blacklist snd_pcsp' >> /etc/modprobe.d/nobeep.conf"
  ```

## Rationale
The existing `/etc/modprobe.d/nobeep.conf` file already contains a more complete configuration including:
- Additional blacklisted beep modules (`hpilo`, `ipmi_si`, `hpwdt`, `toshiba_acpi`)
- Options for PC speaker modules in case they get loaded anyway
- Dummy module installation to prevent the real modules from loading

By removing these lines from the service file, we ensure that the comprehensive configuration remains intact during runtime, providing better beep-silencing functionality.

## Testing
- Verified that the service file syntax is valid
- Confirmed that the comprehensive modprobe configuration remains in place

Fixes #115