### PR TITLE
Add kernel boot parameters for quieter boot experience

### DIFF
--- a/efiboot/loader/entries/01-archiso-x86_64-linux.conf
+++ b/efiboot/loader/entries/01-archiso-x86_64-linux.conf
@@ -2,4 +2,4 @@ title    Arch Linux install medium (x86_64, UEFI)
 sort-key 01
 linux    /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd   /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID%
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet vga=current loglevel=3 udev.log-priority=3

--- a/efiboot/loader/entries/02-archiso-x86_64-speech-linux.conf
+++ b/efiboot/loader/entries/02-archiso-x86_64-speech-linux.conf
@@ -2,4 +2,4 @@ title    Arch Linux install medium (x86_64, UEFI) with speech
 sort-key 02
 linux    /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 initrd   /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on quiet vga=current loglevel=3 udev.log-priority=3

--- a/syslinux/archiso_sys-linux.cfg
+++ b/syslinux/archiso_sys-linux.cfg
@@ -6,7 +6,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS)
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID%
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet vga=current loglevel=3 udev.log-priority=3
 
 # Accessibility boot option
 LABEL arch64speech
@@ -17,4 +17,4 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (x86_64, BIOS) with ^speech
 LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on quiet vga=current loglevel=3 udev.log-priority=3


### PR DESCRIPTION
## Description
This pull request addresses issue #119 by adding kernel boot parameters to both UEFI and SYSLINUX bootloader configurations to provide a quieter boot experience.

## Changes Made
Added the following kernel parameters to all boot configurations:
```
quiet vga=current loglevel=3 udev.log-priority=3
```

Files modified:
1. UEFI bootloader configurations:
   - `efiboot/loader/entries/01-archiso-x86_64-linux.conf`
   - `efiboot/loader/entries/02-archiso-x86_64-speech-linux.conf`

2. SYSLINUX bootloader configurations:
   - `syslinux/archiso_sys-linux.cfg`

## Purpose of Parameters
- `quiet`: Suppresses most kernel messages during boot
- `vga=current`: Prevents mode switching which can cause beeps on some systems
- `loglevel=3`: Reduces verbosity of kernel messages
- `udev.log-priority=3`: Reduces udev log verbosity

## Benefits
- Provides a more seamless and silent user experience
- Complements the existing beep-silencing features
- Makes the system boot process appear more professional

## Testing
- Verified that the configuration files have correct syntax
- Ensured that the accessibility options remain intact alongside the new parameters

Fixes #119