### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-build.yaml
+++ b/.github/workflows/validate-build.yaml
@@ -1,5 +1,8 @@
 name: Validate and Test Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Githubguy132010/Arch-Linux-without-the-beeps/security/code-scanning/2](https://github.com/Githubguy132010/Arch-Linux-without-the-beeps/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily needs read access to the repository contents. Therefore, we will set `contents: read` as the default permission. If any specific job requires additional permissions, they can be defined at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
