### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Build ISO
 
+permissions:
+  contents: write
+  packages: read
+  pull-requests: write
+
 on:
   # Allows manual triggering
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Githubguy132010/Arch-Linux-without-the-beeps/security/code-scanning/1](https://github.com/Githubguy132010/Arch-Linux-without-the-beeps/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's actions, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `contents: write` for creating releases.
- `packages: read` for caching packages.
- `pull-requests: write` for potential pull request updates (if applicable).

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires additional permissions, they can be specified within that job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
